### PR TITLE
replaceState 함수 대신 pushState 함수 사용

### DIFF
--- a/includes/index.php
+++ b/includes/index.php
@@ -93,7 +93,7 @@ Ext.onReady(function () {
 							if (Admin.getMenu() == "modules") {
 								content.on("tabchange",function(tabs,tab) {
 									if (Admin.getTab() != tab.getId() && history.replaceState) {
-										history.replaceState({tab:tab.getId()},tab.getTitle()+" - "+Ext.getCmp("iModuleAdminPanel").getTitle(),"/admin/modules/"+Admin.getPage()+"/"+tab.getId());
+										history.pushState({tab:tab.getId()},tab.getTitle()+" - "+Ext.getCmp("iModuleAdminPanel").getTitle(),"/admin/modules/"+Admin.getPage()+"/"+tab.getId());
 										document.title = tab.getTitle()+" - <?php echo $pageTitle->title; ?>";
 									}
 								});
@@ -102,7 +102,7 @@ Ext.onReady(function () {
 									var tab = tabs.getActiveTab();
 									
 									if (Admin.getTab() != tab.getId() && history.replaceState) {
-										history.replaceState({tab:tab.getId()},tab.getTitle()+" - "+Ext.getCmp("iModuleAdminPanel").getTitle(),"/admin/modules/"+Admin.getPage()+"/"+tab.getId());
+										history.pushState({tab:tab.getId()},tab.getTitle()+" - "+Ext.getCmp("iModuleAdminPanel").getTitle(),"/admin/modules/"+Admin.getPage()+"/"+tab.getId());
 									}
 									
 									document.title = tab.getTitle()+" - <?php echo $pageTitle->title; ?>";


### PR DESCRIPTION
- replaceState는 history 스택의 top을 갈아치우는 함수이고, pushState는 history 스택에 새로운 history를 push 하는 함수였습니다.
- 주소창의 주소를 변경하고, 이전페이지 기록을 추가하는 것이라면, replace가 아닌 push가 맞다고 생각했습니다.